### PR TITLE
ci: use github-pages-deploy reusable

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -13,27 +13,15 @@ permissions:
   id-token: write
 
 concurrency:
-  group: "pages"
+  group: pages
   cancel-in-progress: false
 
 jobs:
   deploy:
     if: >
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.head_branch == 'main'
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup Pages
-        uses: actions/configure-pages@v4
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: '.'
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'main')
+    uses: actionsforge/actions/.github/workflows/github-pages-deploy.yml@main
+    with:
+      path: "."


### PR DESCRIPTION
## Summary
- Replace inline GitHub Pages deploy steps with `actionsforge/actions/.github/workflows/github-pages-deploy.yml@main`
- Keep local `workflow_run` / `workflow_dispatch` triggers and only deploy on success (or manual dispatch)

## Test plan
- [ ] Confirm workflow YAML validates
- [ ] Manually dispatch the Pages workflow (or wait for next content/CI run) and verify Pages still updates

Closes #25