### PR TITLE
fix: drop caller pages concurrency to avoid deadlock

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -12,10 +12,6 @@ permissions:
   pages: write
   id-token: write
 
-concurrency:
-  group: pages
-  cancel-in-progress: false
-
 jobs:
   deploy:
     if: >


### PR DESCRIPTION
## Summary
- Rename `static.yml` → `pages.yml` (where applicable) and match `gcp-icons` caller shape
- Remove caller `concurrency: pages` — it deadlocks with the reusable's own concurrency group ([example](https://github.com/jajera/geonet-http-volcano-demo/actions/runs/30141242930))

## Test plan
- [ ] Manually dispatch **Deploy to GitHub Pages** and confirm build + deploy succeed

Closes #27